### PR TITLE
Add check for uncompressed data blocks (unsupported)

### DIFF
--- a/lz4_frame.asm
+++ b/lz4_frame.asm
@@ -30,6 +30,7 @@ lz4_frame_depack:
 		move.b	4(a0),d0
 		swap	d0
 		move.b	6(a0),d0
+		bmi.b	lz4_frame_error		; top bit set == uncompressed
 		lsl.l	#8,d0
 		move.b	5(a0),d0
 		swap	d0


### PR DESCRIPTION
While testing lz4 for various data sets, I 'accidentally' fed it (something close to) random noise where lz4 will opt to emit uncompressed data blocks.
And subsequently noticed there is a check missing for this case.
(`"If the highest bit is set (1), the block is uncompressed."` [lz4_Frame_format.md](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md#data-blocks))